### PR TITLE
fix: false RST for jets on type-restricted SIDs when no SID-level restriction is applicable

### DIFF
--- a/VFPC.vcxproj
+++ b/VFPC.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClInclude Include="resource.h" />
     <ClInclude Include="src\analyzeFP.hpp" />
+    <ClInclude Include="src\SidApplicability.hpp" />
     <ClInclude Include="src\Constant.hpp" />
     <ClInclude Include="src\stdafx.h" />
     <ClInclude Include="src\targetver.h" />

--- a/VFPC_Tests/ApiConstraintTests.cpp
+++ b/VFPC_Tests/ApiConstraintTests.cpp
@@ -373,4 +373,110 @@ TEST(ApiConstraint_Integration, EGSC_EGPF_Line19488_LowBand)
     EXPECT_FALSE(checkOneMinMax (c, 10000));  // FL100 — below min
 }
 
+// ── SidApplicability — anySidLevelRestrictionApplicable ──────────────────────
+//
+// Regression tests for the EGPH/TLA jet case (issue #174).
+//
+// The bug: jets on EGPH TLA outside 2300-0559 got RST instead of RTE/DST.
+// Root cause: the only sidlevel=true restriction (types=["J"], 2300-0559)
+// was not applicable outside its time window, but the code treated
+// "no SID-level restriction applicable" as "SID-level restriction failed".
+//
+// Data mirror of in.json EGPH/TLA restrictions array (AIRAC 2603):
+//   Restriction 0: types=["T","P","E"], no sidlevel  → SID-level: skip
+//   Restriction 1: types=["J"], 2300-0559, sidlevel=true
+//
+// Day convention: Monday=0 … Sunday=6 (matches timedata[5] in production).
+
+#include "SidApplicability.hpp"
+using namespace SidApplicability;
+
+// The restrictions JSON used in all EGPH/TLA tests below.
+// Mirrors the live in.json EGPH TLA entry exactly.
+static const char* EGPH_TLA_RESTRICTIONS = R"([
+    {
+        "types": ["T","P","E"],
+        "alt":   ["GOSAM"]
+    },
+    {
+        "types":    ["J"],
+        "route":    ["N864","N57","L612","UN864","UN57","UL612"],
+        "start":    {"time":"2300"},
+        "end":      {"time":"0559"},
+        "sidlevel": true
+    }
+])";
+
+// ── Issue #174 core regression: jet outside 2300-0559 → no SID-level restriction applicable
+
+TEST(SidApplicability_EgphTla, Jet_OutsideWindow_NoSidLevelApplicable)
+{
+    // A jet (engine type "J") on TLA at 14:00 UTC (well outside 2300-0559).
+    // Restriction 0 is not sidlevel — skipped.
+    // Restriction 1 is sidlevel=true, types=["J"] matches, but time window fails.
+    // Expected: false — no SID-level restriction is applicable.
+    // This is the exact scenario that produced false RST before the #174 fix.
+    JSON(doc, EGPH_TLA_RESTRICTIONS);
+    ASSERT_FALSE(doc.HasParseError());
+    EXPECT_FALSE(anySidLevelRestrictionApplicable(doc, "J", "B738", "", 0, 14, 0))
+        << "Jet on TLA at 14:00 should have no applicable SID-level restriction";
+}
+
+// ── Jet inside the night window → SID-level restriction IS applicable
+
+TEST(SidApplicability_EgphTla, Jet_InsideWindow_SidLevelApplicable)
+{
+    // A jet (engine type "J") on TLA at 23:30 UTC (inside 2300-0559).
+    // Restriction 1: sidlevel=true, types=["J"] matches, time window passes.
+    // Expected: true — the SID-level night restriction applies.
+    JSON(doc, EGPH_TLA_RESTRICTIONS);
+    ASSERT_FALSE(doc.HasParseError());
+    EXPECT_TRUE(anySidLevelRestrictionApplicable(doc, "J", "B738", "", 0, 23, 30))
+        << "Jet on TLA at 23:30 should have an applicable SID-level restriction";
+}
+
+// ── Turboprop on TLA → restriction 0 is not sidlevel, restriction 1 type mismatch
+
+TEST(SidApplicability_EgphTla, Turboprop_NoSidLevelRestrictions)
+{
+    // A turboprop (engine type "T") on TLA — at any time.
+    // Restriction 0: types=["T","P","E"] matches, but it has NO sidlevel flag — skipped.
+    // Restriction 1: sidlevel=true, types=["J"] — type mismatch.
+    // Expected: false — no SID-level restriction applies to turboprops.
+    JSON(doc, EGPH_TLA_RESTRICTIONS);
+    ASSERT_FALSE(doc.HasParseError());
+    EXPECT_FALSE(anySidLevelRestrictionApplicable(doc, "T", "DH8D", "", 0, 14, 0))
+        << "Turboprop on TLA should have no applicable SID-level restriction";
+}
+
+// ── Empty restrictions array → never applicable
+
+TEST(SidApplicability_EdgeCases, EmptyArray_ReturnsFalse)
+{
+    JSON(doc, R"([])");
+    ASSERT_FALSE(doc.HasParseError());
+    EXPECT_FALSE(anySidLevelRestrictionApplicable(doc, "J", "B738", "", 0, 14, 0));
+}
+
+// ── No sidlevel restrictions at all → never applicable
+
+TEST(SidApplicability_EdgeCases, NoSidLevelRestrictions_ReturnsFalse)
+{
+    // Array with a non-sidlevel type restriction only.
+    JSON(doc, R"([{"types":["J"]}])");
+    ASSERT_FALSE(doc.HasParseError());
+    EXPECT_FALSE(anySidLevelRestrictionApplicable(doc, "J", "B738", "", 0, 14, 0));
+}
+
+// ── sidlevel restriction with no selectors → always applicable
+
+TEST(SidApplicability_EdgeCases, SidLevelNoSelectors_AlwaysApplicable)
+{
+    // A sidlevel restriction with no types, suffix, or time filter — applies to all flights.
+    JSON(doc, R"([{"sidlevel":true,"alt":["OTHER"]}])");
+    ASSERT_FALSE(doc.HasParseError());
+    EXPECT_TRUE(anySidLevelRestrictionApplicable(doc, "J", "B738", "", 0, 14, 0));
+    EXPECT_TRUE(anySidLevelRestrictionApplicable(doc, "T", "DH8D", "2C", 0, 3, 0));
+}
+
 // main() is defined in TimeWindowTests.cpp — one entry point for the whole suite.

--- a/VFPC_Tests/VFPC_Tests.vcxproj
+++ b/VFPC_Tests/VFPC_Tests.vcxproj
@@ -102,6 +102,7 @@
   <ItemGroup>
     <ClInclude Include="$(SolutionDir)src\TimeWindow.hpp" />
     <ClInclude Include="$(SolutionDir)src\ConstraintChecks.hpp" />
+    <ClInclude Include="$(SolutionDir)src\SidApplicability.hpp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SidApplicability.hpp
+++ b/src/SidApplicability.hpp
@@ -1,0 +1,124 @@
+// SidApplicability.hpp
+// Pure, standalone inline function for testing whether any SID-level restriction
+// in a restrictions array is currently applicable to a given flight.
+//
+// "Applicable" means ALL of the restriction's selectors match:
+//   - sidlevel == true          (only SID-level restrictions are considered)
+//   - suffix matches, or no suffix selector exists
+//   - type matches, or no type selector exists
+//   - time window passes, or no time selector exists
+//
+// This function drives the sidwide fallback in validateSid (analyzeFP.cpp).
+// Extracted here so it can be unit-tested without EuroScope dependencies.
+//
+// Usage in production:
+//   #include "SidApplicability.hpp"
+//   bool active = anySidLevelRestrictionApplicable(
+//       sid_ele["restrictions"], eng, actype, sid_suffix,
+//       timedata[5], timedata[3], timedata[4]);
+//
+// Usage in tests:
+//   #include "SidApplicability.hpp"
+//   using namespace SidApplicability;
+
+#pragma once
+
+#include "rapidjson/document.h"
+#include "TimeWindow.hpp"
+#include <string>
+
+namespace SidApplicability {
+
+using namespace rapidjson;
+
+// Returns true if at least one restriction in the array has sidlevel=true and
+// all of its selectors (suffix, type, time window) match the current flight.
+//
+// Returns false if:
+//   - the array is empty or absent
+//   - every sidlevel=true restriction fails at least one selector
+//   - there are no sidlevel=true restrictions at all
+//
+// Parameters:
+//   restrictions  — the "restrictions" JSON array from a SID element
+//   eng           — GetEngineType() for the flight (e.g. "J", "T", "P", "E")
+//   actype        — GetAircraftType() for the flight (e.g. "B738")
+//   sid_suffix    — the SID suffix string (e.g. "1C", "2D", "")
+//   currentDay    — current day-of-week (Monday=0 … Sunday=6, per timedata[5])
+//   currentHour   — current UTC hour (0-23, per timedata[3])
+//   currentMin    — current UTC minute (0-59, per timedata[4])
+inline bool anySidLevelRestrictionApplicable(
+    const Value& restrictions,
+    const std::string& eng,
+    const std::string& actype,
+    const std::string& sid_suffix,
+    int currentDay,
+    int currentHour,
+    int currentMin)
+{
+    if (!restrictions.IsArray() || restrictions.Size() == 0) {
+        return false;
+    }
+
+    for (SizeType i = 0; i < restrictions.Size(); i++) {
+        const Value& r = restrictions[i];
+
+        // Only SID-level restrictions are considered here.
+        if (!r.HasMember("sidlevel") || !r["sidlevel"].GetBool()) {
+            continue;
+        }
+
+        bool applicable = true;
+
+        // Suffix selector: absent means applies to all suffixes.
+        if (r.HasMember("suffix") && r["suffix"].IsArray() && r["suffix"].Size()) {
+            bool suffixFound = false;
+            for (SizeType j = 0; j < r["suffix"].Size(); j++) {
+                if (r["suffix"][j].IsString()) {
+                    std::string sfx = r["suffix"][j].GetString();
+                    // Match if sid_suffix ends with the selector value (mirrors arrayContainsEnding).
+                    if (sid_suffix.size() >= sfx.size() &&
+                        sid_suffix.compare(sid_suffix.size() - sfx.size(), sfx.size(), sfx) == 0) {
+                        suffixFound = true;
+                        break;
+                    }
+                }
+            }
+            if (!suffixFound) {
+                applicable = false;
+            }
+        }
+
+        // Type selector: absent means applies to all types.
+        if (applicable && r.HasMember("types") && r["types"].IsArray() && r["types"].Size()) {
+            bool typeFound = false;
+            for (SizeType j = 0; j < r["types"].Size(); j++) {
+                if (r["types"][j].IsString()) {
+                    std::string t = r["types"][j].GetString();
+                    if (t == eng || t == actype) {
+                        typeFound = true;
+                        break;
+                    }
+                }
+            }
+            if (!typeFound) {
+                applicable = false;
+            }
+        }
+
+        // Time window selector: only active when both start and end are present.
+        if (applicable && r.HasMember("start") && r.HasMember("end")) {
+            if (!checkTimeWindow(currentDay, currentHour, currentMin, r)) {
+                applicable = false;
+            }
+        }
+
+        if (applicable) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace SidApplicability

--- a/src/analyzeFP.cpp
+++ b/src/analyzeFP.cpp
@@ -2,6 +2,7 @@
 #include "analyzeFP.hpp"
 #include "TimeWindow.hpp"
 #include "ConstraintChecks.hpp"
+#include "SidApplicability.hpp"
 
 using namespace ConstraintChecks;
 #include <curl/curl.h>
@@ -1294,54 +1295,16 @@ vector<vector<string>> CVFPCPlugin::validateSid(CFlightPlan flightPlan) {
 		// Scope: this is intentionally narrow. It does not change the case where a SID-level
 		// restriction IS applicable and fails — that still produces RST as before.
 		if (!sidwide) {
-			const Value& sidRestrictions = sid_ele["restrictions"];
-			bool anySidLevelApplicable = false;
+			// Delegate to SidApplicability.hpp — see that file for full documentation.
+			// If no SID-level restriction is currently applicable to this flight,
+			// fall back to the constraint-loop result rather than forcing RST.
+			bool anySidLevelApplicable = SidApplicability::anySidLevelRestrictionApplicable(
+				sid_ele["restrictions"],
+				flightPlan.GetFlightPlanData().GetEngineType(),
+				flightPlan.GetFlightPlanData().GetAircraftType(),
+				sid_suffix,
+				timedata[5], timedata[3], timedata[4]);
 
-			if (sidRestrictions.IsArray() && sidRestrictions.Size()) {
-				const string eng    = flightPlan.GetFlightPlanData().GetEngineType();
-				const string actype = flightPlan.GetFlightPlanData().GetAircraftType();
-
-				for (SizeType i = 0; i < sidRestrictions.Size(); i++) {
-					const Value& r = sidRestrictions[i];
-
-					// Only SID-level restrictions can make the SID-wide output path fire.
-					if (!r.HasMember("sidlevel") || !r["sidlevel"].GetBool()) {
-						continue;
-					}
-
-					bool applicable = true;
-
-					// Suffix selector: absent means applies to all suffixes.
-					if (r.HasMember("suffix") && r["suffix"].IsArray() && r["suffix"].Size()) {
-						if (!arrayContainsEnding(r["suffix"], sid_suffix)) {
-							applicable = false;
-						}
-					}
-
-					// Type selector: absent means applies to all types.
-					if (applicable && r.HasMember("types") && r["types"].IsArray() && r["types"].Size()) {
-						if (!arrayContains(r["types"], eng) &&
-							!arrayContains(r["types"], actype)) {
-							applicable = false;
-						}
-					}
-
-					// Time window selector: only active when both start and end are present.
-					if (applicable && r.HasMember("start") && r.HasMember("end")) {
-						if (!checkTimeWindow(timedata[5], timedata[3], timedata[4], r)) {
-							applicable = false;
-						}
-					}
-
-					if (applicable) {
-						anySidLevelApplicable = true;
-						break;
-					}
-				}
-			}
-
-			// No SID-level restriction applies to this flight right now.
-			// Fall back to the constraint-loop result rather than forcing RST.
 			if (!anySidLevelApplicable) {
 				sidwide = true;
 			}

--- a/src/analyzeFP.cpp
+++ b/src/analyzeFP.cpp
@@ -1255,16 +1255,96 @@ vector<vector<string>> CVFPCPlugin::validateSid(CFlightPlan flightPlan) {
 		int round = 0;
 		vector<bool> validity, new_validity;
 		vector<string> results;
-		bool sidFails[4]{ 0 };
+		// sidFails: written to only by sidlevel=true restrictions. Controls the SID-wide RST
+		// fallback output path below. Initialised with suffix-fail true (index 0) to match the
+		// original convention that a suffix failure is assumed until a restriction clears it.
+		bool sidFails[4]{ true, false, false, false };
+		// constFails: written to by non-sidlevel (constraint-level) restrictions. Kept separate
+		// from sidFails so that constraint-level failures cannot pollute the SID-wide output path.
+		// This buffer is not read after the checkRestriction call; it just gives the function
+		// somewhere to write non-sidlevel failure flags without contaminating sidFails.
+		bool constFails[4]{ true, false, false, false };
 		bool restFails[4]{ 0 }; // 0 = Suffix, 1 = Aircraft/Engines, 2 = Date/Time Restrictions
 		bool warn = false;
 
 		//SID-Level Restrictions Array
-		sidFails[0] = true;
-		vector<bool> temp = checkRestriction(flightPlan, sid_suffix, sid_ele["restrictions"], sidFails, sidFails);
+		vector<bool> temp = checkRestriction(flightPlan, sid_suffix, sid_ele["restrictions"], sidFails, constFails);
 		bool sidwide = false;
 		if (temp[0] || temp[1]) {
 			sidwide = true;
+		}
+
+		// Issue #174 fix: if sidwide is still false, it may be because no SID-level restriction
+		// is currently applicable to this flight — not because one actively blocked it.
+		//
+		// A SID-level restriction is "applicable" only when ALL of its selectors match:
+		//   - sidlevel == true
+		//   - suffix matches, or no suffix selector exists
+		//   - type matches, or no type selector exists
+		//   - time window passes, or no time selector exists
+		//
+		// If no SID-level restriction is applicable, forcing RST is wrong. Instead we fall
+		// through to the normal constraint-loop result (DST, RTE, etc.).
+		//
+		// Concrete case this fixes: EGPH TLA, jet aircraft, outside 2300-0559.
+		//   Restriction 0 (types T/P/E): not applicable — type mismatch.
+		//   Restriction 1 (sidlevel, types J, 2300-0559): not applicable outside the window.
+		//   => no SID-level restriction applies => use constraint-loop round result, not RST.
+		//
+		// Scope: this is intentionally narrow. It does not change the case where a SID-level
+		// restriction IS applicable and fails — that still produces RST as before.
+		if (!sidwide) {
+			const Value& sidRestrictions = sid_ele["restrictions"];
+			bool anySidLevelApplicable = false;
+
+			if (sidRestrictions.IsArray() && sidRestrictions.Size()) {
+				const string eng    = flightPlan.GetFlightPlanData().GetEngineType();
+				const string actype = flightPlan.GetFlightPlanData().GetAircraftType();
+
+				for (SizeType i = 0; i < sidRestrictions.Size(); i++) {
+					const Value& r = sidRestrictions[i];
+
+					// Only SID-level restrictions can make the SID-wide output path fire.
+					if (!r.HasMember("sidlevel") || !r["sidlevel"].GetBool()) {
+						continue;
+					}
+
+					bool applicable = true;
+
+					// Suffix selector: absent means applies to all suffixes.
+					if (r.HasMember("suffix") && r["suffix"].IsArray() && r["suffix"].Size()) {
+						if (!arrayContainsEnding(r["suffix"], sid_suffix)) {
+							applicable = false;
+						}
+					}
+
+					// Type selector: absent means applies to all types.
+					if (applicable && r.HasMember("types") && r["types"].IsArray() && r["types"].Size()) {
+						if (!arrayContains(r["types"], eng) &&
+							!arrayContains(r["types"], actype)) {
+							applicable = false;
+						}
+					}
+
+					// Time window selector: only active when both start and end are present.
+					if (applicable && r.HasMember("start") && r.HasMember("end")) {
+						if (!checkTimeWindow(timedata[5], timedata[3], timedata[4], r)) {
+							applicable = false;
+						}
+					}
+
+					if (applicable) {
+						anySidLevelApplicable = true;
+						break;
+					}
+				}
+			}
+
+			// No SID-level restriction applies to this flight right now.
+			// Fall back to the constraint-loop result rather than forcing RST.
+			if (!anySidLevelApplicable) {
+				sidwide = true;
+			}
 		}
 
 		//Initialise validity array to fully true#
@@ -1442,7 +1522,9 @@ vector<vector<string>> CVFPCPlugin::validateSid(CFlightPlan flightPlan) {
 				returnOut[0][6] = "Valid Suffix.";
 				returnOut[1][6] = "Valid " + SuffixOutput(flightPlan, sid_ele);
 
-				//sidFails[1], [2], or [3] must be false to get here
+				// Reaching here means at least one SID-level restriction was applicable to this
+				// flight (suffix/type/time all matched) and it failed — RST is the correct result.
+				// sidFails now contains SID-level failures only (constFails was separated above).
 				returnOut[1][8] = returnOut[0][8] = "Failed " + RestrictionsOutput(flightPlan, sid_ele, sidFails[1], sidFails[2], sidFails[3]) + " " + AlternativesOutput(flightPlan, sid_ele);
 			}
 		}


### PR DESCRIPTION
## Summary
- replay the #174 fix onto current main without the stale housekeeping reversions from the original branch
- keep the SID-wide evaluation fix and extracted SidApplicability.hpp helper
- retain the regression coverage for the EGPH/TLA jet case

## Why this PR exists
The original implementation branch was valid but stale relative to current main. This PR is the same fix rebuilt cleanly on top of the merged envelope-test change from #181, so it is reviewable again without unrelated branch noise.

## Validation
- built VFPC_Tests with MSBuild
- ran in\\Debug\\tests\\VFPC_Tests.exe
- result: 94/94 passing

## Note
This PR supersedes the earlier closed PR #176 structurally, but it does **not** change the earlier data-audit discussion around EGPH/TLA. That context should still be considered before deciding whether to merge.